### PR TITLE
Fix internal link navigation to account for fixed header height

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -115,6 +115,72 @@ const { title, description = "25 Mobility Trailblazers in 25 – Weil mobiler Wa
 	<body>
 		<slot />
 		<ScrollToTop />
+		
+		<!-- Enhanced scroll behavior for internal links -->
+		<script is:inline>
+		(function() {
+			// Header height offset (approximately 89px + 11px buffer = 100px)
+			var HEADER_OFFSET = 100;
+			
+			// Function to smoothly scroll to element with offset
+			function smoothScrollToElement(targetId) {
+				var target = document.getElementById(targetId);
+				if (!target) return false;
+				
+				var targetPosition = target.getBoundingClientRect().top + window.pageYOffset - HEADER_OFFSET;
+				
+				// Use modern scrollTo with smooth behavior if supported
+				if ('scrollBehavior' in document.documentElement.style) {
+					window.scrollTo({
+						top: targetPosition,
+						behavior: 'smooth'
+					});
+				} else {
+					// Fallback for older browsers
+					window.scrollTo(0, targetPosition);
+				}
+				return true;
+			}
+			
+			// Handle internal link clicks
+			function handleInternalLinks() {
+				var links = document.querySelectorAll('a[href^="#"], a[href^="/#"]');
+				
+				for (var i = 0; i < links.length; i++) {
+					links[i].addEventListener('click', function(e) {
+						var href = this.getAttribute('href');
+						var targetId = href.replace(/^\/?#/, ''); // Remove leading /# or #
+						
+						if (targetId && smoothScrollToElement(targetId)) {
+							e.preventDefault();
+							// Update URL without jumping
+							if (history.pushState) {
+								history.pushState(null, null, '#' + targetId);
+							} else {
+								// Fallback for older browsers
+								window.location.hash = targetId;
+							}
+						}
+					});
+				}
+			}
+			
+			// Initialize when DOM is ready
+			if (document.readyState === 'loading') {
+				document.addEventListener('DOMContentLoaded', handleInternalLinks);
+			} else {
+				handleInternalLinks();
+			}
+			
+			// Handle direct hash navigation on page load
+			if (window.location.hash) {
+				setTimeout(function() {
+					var targetId = window.location.hash.substring(1);
+					smoothScrollToElement(targetId);
+				}, 100);
+			}
+		})();
+		</script>
 	</body>
 </html>
 
@@ -126,7 +192,6 @@ const { title, description = "25 Mobility Trailblazers in 25 – Weil mobiler Wa
 	}
 
 	html {
-		scroll-behavior: smooth;
 		background-color: #F8F0E3;
 	}
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,6 +44,8 @@
 html {
 	scroll-behavior: smooth;
 	background-color: #F8F0E3;
+	/* Add scroll padding to account for fixed header */
+	scroll-padding-top: 100px;
 }
 
 body {


### PR DESCRIPTION
Fixes issue where clicking internal navigation links would scroll content behind the fixed header.

## Changes

- Add `scroll-padding-top: 100px` to html element for modern browsers
- Implement JavaScript enhancement for smooth scrolling with header offset
- Handle both #section and /#section link formats
- Support for direct hash navigation on page load
- Fallback support for older browsers
- Proper URL updates without page jumps

Closes #11

Generated with [Claude Code](https://claude.ai/code)