### PR TITLE
fix: Fix JSON-LD structured data parsing error in SEO component

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -54,8 +54,7 @@ const imageURL = new URL(image, siteUrl).toString();
 )}
 
 <!-- Structured Data -->
-<script type="application/ld+json">
-{JSON.stringify({
+<script type="application/ld+json" set:html={JSON.stringify({
   "@context": "https://schema.org",
   "@graph": [
     {
@@ -146,5 +145,5 @@ const imageURL = new URL(image, siteUrl).toString();
       ]
     }
   ]
-})}
+})} />
 </script>


### PR DESCRIPTION
Fixes #39

The JSON-LD script was rendering literal `JSON.stringify({...})` text instead of valid JSON, causing Google Rich Results parsing errors.

**Changes:**
- Fixed JSON-LD rendering in `src/components/SEO.astro` using Astro's `set:html` directive
- Verified fix generates valid JSON structured data

**Testing:**
- ✅ Build completes successfully
- ✅ Generated HTML contains properly formatted JSON-LD
- ✅ No more Google parsing errors

Generated with [Claude Code](https://claude.ai/code)