### PR TITLE
fix: Fix countdown responsive test serialization issue

### DIFF
--- a/tests/core.spec.ts
+++ b/tests/core.spec.ts
@@ -263,7 +263,12 @@ test.describe('Core Functionality Tests', () => {
       // Check if items are properly arranged (uses grid on mobile)
       const container = homePage.countdownContainer;
       const containerStyles = await container.evaluate((el) => {
-        return window.getComputedStyle(el);
+        const styles = window.getComputedStyle(el);
+        return {
+          display: styles.display,
+          gridTemplateColumns: styles.gridTemplateColumns,
+          gridTemplateRows: styles.gridTemplateRows
+        };
       });
       
       // Should use grid layout on mobile (375px width)
@@ -271,7 +276,10 @@ test.describe('Core Functionality Tests', () => {
       // Check that it has two equal columns (computed styles will be in pixels)
       const columns = containerStyles.gridTemplateColumns.split(' ');
       expect(columns).toHaveLength(2);
-      expect(columns[0]).toBe(columns[1]); // Should be equal width
+      // Both columns should have the same width (allowing for minor rounding differences)
+      const col1Width = parseFloat(columns[0]);
+      const col2Width = parseFloat(columns[1]);
+      expect(Math.abs(col1Width - col2Width)).toBeLessThan(1); // Allow 1px difference for rounding
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed failing Playwright test that was getting `undefined` for CSS display property
- Test now correctly verifies that countdown uses CSS Grid layout on mobile viewports

## Problem
The test at `core.spec.ts:270` was failing with:
```
Error: expect(received).toBe(expected)
Expected: "grid"
Received: undefined
```

This occurred because `window.getComputedStyle(el)` returns a `CSSStyleDeclaration` object that cannot be properly serialized when passed from the browser context to the Node.js test runner.

## Solution
- Modified the test to extract specific CSS properties (`display`, `gridTemplateColumns`, `gridTemplateRows`) within the browser context
- Updated grid column assertion to handle pixel values with tolerance for rounding differences
- The countdown container correctly uses `display: grid` with 2 equal columns on mobile (375px width)

## Test Results
✅ Test now passes on both Chrome and Firefox:
```
✓ [Desktop Chrome] › tests\core.spec.ts:251:5 › countdown should be responsive (1.9s)
✓ [Desktop Firefox] › tests\core.spec.ts:251:5 › countdown should be responsive (5.1s)
```

## Review Request
@claude and @codex - Please review this fix for the Playwright test serialization issue.

🤖 Generated with [Claude Code](https://claude.ai/code)