### PR TITLE
Fix Tarteaucitron MS Edge MIME type error

### DIFF
--- a/public/tarteaucitron/tarteaucitron.services.js
+++ b/public/tarteaucitron/tarteaucitron.services.js
@@ -1,0 +1,57 @@
+/*! tarteaucitron.js v1.17.1 | https://github.com/AmauriC/tarteaucitron.js | Copyright 2013-2024 - Amauri Champeaux | License: MIT */
+/* Minimal services file - Contains only services used by this site */
+/* global tarteaucitron */
+
+// Google Analytics (GA4) Service
+tarteaucitron.services.gtag = {
+    "key": "gtag",
+    "type": "analytic",
+    "name": "Google Analytics (GA4)",
+    "uri": "https://policies.google.com/privacy",
+    "needConsent": true,
+    "cookies": (function () {
+        var googleIdentifier = tarteaucitron.user.gtagUa,
+            tagUaCookie = '_gat_gtag_' + googleIdentifier,
+            tagGCookie = '_ga_' + googleIdentifier;
+
+        tagUaCookie = tagUaCookie.replace(/-/g, '_');
+        tagGCookie = tagGCookie.replace(/G-/g, '');
+
+        return ['_ga', '_gat', '_gid', '__utma', '__utmb', '__utmc', '__utmt', '__utmz', tagUaCookie, tagGCookie, '_gcl_au'];
+    })(),
+    "js": function () {
+        "use strict";
+
+        if (tarteaucitron.user.gtagUa === undefined) {
+            return;
+        }
+
+        window.dataLayer = window.dataLayer || [];
+        tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + tarteaucitron.user.gtagUa, '', function () {
+            window.gtag = function gtag() { dataLayer.push(arguments); }
+            gtag('js', new Date());
+            var additional_config_info = (typeof timeExpire !== 'undefined') ? {'anonymize_ip': true, 'cookie_expires': timeExpire / 1000} : {'anonymize_ip': true};
+
+            if (tarteaucitron.user.gtagCrossdomain) {
+                /**
+                 * https://support.google.com/analytics/answer/7476333?hl=en
+                 * https://developers.google.com/analytics/devguides/collection/gtagjs/cross-domain
+                 */
+                gtag('config', tarteaucitron.user.gtagUa, additional_config_info, { linker: { domains: tarteaucitron.user.gtagCrossdomain, } });
+            } else {
+                gtag('config', tarteaucitron.user.gtagUa, additional_config_info);
+            }
+
+            if (typeof tarteaucitron.user.gtagMore === 'function') {
+                tarteaucitron.user.gtagMore();
+            }
+        });
+    },
+    "fallback": function () {
+        if (tarteaucitron.parameters.googleConsentMode === true) {
+            if (tarteaucitron.parameters.softConsentMode === false) {
+                this.js();
+            }
+        }
+    }
+};


### PR DESCRIPTION
Fixes #48

This PR resolves the Tarteaucitron cookie consent bug that was preventing the SocialKit widget from loading in MS Edge.

## Problem
MS Edge was rejecting the Tarteaucitron script due to a MIME type error. The main `tarteaucitron.js` file automatically tries to load `tarteaucitron.services.js`, but we only had `tarteaucitron.services.minimal.js`. This caused a 404 that returned HTML, triggering the MIME type error.

## Solution
- Created the missing `tarteaucitron.services.js` by copying from the minimal version
- File now serves with correct `Content-Type: text/javascript`
- Cookie consent system initializes properly in all browsers
- SocialKit widget can now load after consent

Generated with [Claude Code](https://claude.ai/code)